### PR TITLE
feat: code-group

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"@shikijs/langs": "^3.9.2",
 		"@shikijs/rehype": "^3.9.2",
 		"@shikijs/themes": "^3.9.2",
+		"@types/hast": "^3.0.4",
 		"@types/mdast": "^4.0.4",
 		"@types/node": "^24.2.1",
 		"@types/react": "^19.1.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@shikijs/themes':
         specifier: ^3.9.2
         version: 3.9.2
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.4
       '@types/mdast':
         specifier: ^4.0.4
         version: 4.0.4

--- a/src/lib/plugins/markdown.ts
+++ b/src/lib/plugins/markdown.ts
@@ -11,6 +11,7 @@ import remarkMdxFrontmatter from "remark-mdx-frontmatter";
 import type { ShikiTransformer } from "shiki";
 import { createHighlighterCore } from "shiki/core";
 import { createOnigurumaEngine } from "shiki/engine/oniguruma";
+import type * as unified from "unified";
 import { visit } from "unist-util-visit";
 import { VFile } from "vfile";
 import type { Plugin } from "vite";
@@ -81,8 +82,8 @@ const CUSTOM_BLOCKS = ["info", "tip", "warning", "danger", "details"];
 // https://vitepress.dev/guide/markdown#github-flavored-alerts
 const GITHUB_ALERTS = ["note", "tip", "important", "warning", "caution"];
 
-function remarkCustom() {
-	return function (tree: Root, file: VFile) {
+const remarkCustom: unified.Plugin<[], Root> = () => {
+	return function (tree, file) {
 		visit(tree, function (node) {
 			// https://github.com/remarkjs/remark-directive/
 			if (
@@ -143,7 +144,7 @@ function remarkCustom() {
 			GITHUB_ALERTS;
 		});
 	};
-}
+};
 
 // https://github.com/vitejs/vite-plugin-vue/blob/06931b1ea2b9299267374cb8eb4db27c0626774a/packages/plugin-vue/src/utils/query.ts#L13
 function parseIdQuery(id: string): {


### PR DESCRIPTION
We want to test some simple client component (since so far none!). Maybe we should port docusaurus's primitives like https://docusaurus.io/docs/markdown-features/tabs.